### PR TITLE
Inline search

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ npm run build
 
 4. Click export button to copy data JSON to clipboard. Then paste the JSON into `src/data`.
 
+   Alternately, you can apply for a Flickr API key [here](https://www.flickr.com/services/apps/create/apply/), and either paste it into the textbox requesting it on the editor page or add the following to a .env.local file on project root:
+   ```
+   VUE_APP_FLICKR_API=<your flicker key here>
+   ```
+   This will allow inline search and fetching.  
+
 ## Adding models
 1. Put the .obj file into `public/assets/models`. It's better to keep files within 1MB. I use Blender and MeshLab to reduce the models.
 

--- a/src/rawSearch.js
+++ b/src/rawSearch.js
@@ -1,0 +1,1 @@
+export default [];


### PR DESCRIPTION
I wanted to make searching for images as mindless as possible, so I've made the editor able to take a Flickr API key and do the searching from within itself.

![art-tool-1](https://user-images.githubusercontent.com/3222168/54732196-7564e180-4b60-11e9-9a54-8b2eb240e1cc.gif)

The person running the editor locally can either paste their Flickr API key into a box prompting them to do so, or it can be dumped into .env.local for convenience.  

The old workflow has been preserved. You can dump the search array into rawSearch.js to basically do the same thing but with an assumed url format.  