### PR TITLE
Silence Three.js warnings

### DIFF
--- a/src/components/ModelViewer.vue
+++ b/src/components/ModelViewer.vue
@@ -149,11 +149,13 @@
                         const mesh = obj.children[0];
                         const box = new THREE.Box3().setFromObject(obj);
 
-                        const center = box.getCenter();
+                        const center = new THREE.Vector3();
+                        box.getCenter(center);
                         mesh.position.set(-center.x, -center.y, -center.z);
 
                         // resize
-                        const size = box.getSize();
+                        const size = new THREE.Vector3();
+                        box.getSize(size);
                         const scale = this.preferSize / Math.max(size.x, size.y, size.z);
                         mesh.scale.set(scale, scale, scale);
 


### PR DESCRIPTION
Fixes Three.js warnings, in reference to Issue #4:

![image](https://user-images.githubusercontent.com/3222168/55903276-e7927a00-5b92-11e9-81e0-8c9a3c9b7e5f.png)

The warning "THREE.MeshPhongMaterial: .shading has been removed. Use the boolean .flatShading instead." is still waiting on a Three-obj-importer pull request and as such, can't be fixed yet:

https://github.com/sohamkamani/three-object-loader/pull/19



