### PR TITLE
Web Preview

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,11 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <meta itemprop="name" content="Animal Photo Art References Search" />
+    <meta itemprop="description" content="Search real animal photo references by a turnable animal skull model" />
+    <meta property="og:url" content="https://x6ud.github.io/#/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="x6ud.github.io" />
     <title>Animal Photo Art References Search</title>
 
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-135663583-1"></script>


### PR DESCRIPTION
I didn't realize that the search tool has it's own repo, so here's the change from the github.io repo.

Maybe put a placeholder url? Up 2 u